### PR TITLE
Allow to configure digits

### DIFF
--- a/lib/memorable_password.rb
+++ b/lib/memorable_password.rb
@@ -30,8 +30,7 @@ require 'memorable_password/sample'
 #
 class MemorablePassword
   MAX_WORD_LENGTH = 7
-  DIGITS = %w[0 1 2 3 4 5 6 7 8 9].freeze
-  NON_WORD_DIGITS = (DIGITS - %w(2 4 8)).freeze
+  DEFAULT_DIGITS = %w[0 1 2 3 4 5 6 7 8 9].freeze
   CHARACTERS = %w[! @ $ ? -].freeze
 
   # The default paths to the various dictionary flat files
@@ -47,7 +46,7 @@ class MemorablePassword
   }
 
   attr_reader :dictionary, :blacklist, :ban_list,
-              :dictionary_paths, :blacklist_paths
+              :dictionary_paths, :blacklist_paths, :digits, :non_word_digits
 
   def initialize(options={})
     # TODO implement these lists as Sets to get Hash lookup and uniqueness for free -- matt.dressel 20120328
@@ -57,6 +56,9 @@ class MemorablePassword
     # TODO support passing data in as an array -- matt.dressel 20120328
     @dictionary_paths = options.fetch(:dictionary_paths, DEFAULT_DICTIONARY_PATHS)
     @blacklist_paths = options.fetch(:blacklist_paths, DEFAULT_BLACKLIST_PATHS)
+
+    @digits = options.fetch(:digits, DEFAULT_DIGITS).freeze
+    @non_word_digits = (@digits - %w(2 4 8)).freeze
 
     @dictionary = {}
     @blacklist = []
@@ -168,12 +170,12 @@ class MemorablePassword
 
   # Returns a random digit
   def digit
-    DIGITS.sample
+    @digits.sample
   end
 
   # Returns a random, non-ambiguous digit (0..9 without 2, 4 and 8)
   def non_word_digit
-    NON_WORD_DIGITS.sample
+    @non_word_digits.sample
   end
 
   # Ensures that the word is valid:

--- a/spec/lib/memorable_password_spec.rb
+++ b/spec/lib/memorable_password_spec.rb
@@ -6,7 +6,8 @@ describe MemorablePassword do
     default_path = "#{File.dirname(__FILE__)}/config"
     @memorable_password ||= MemorablePassword.new(
                               :dictionary_paths => ["#{default_path}/custom_dictionary.txt"],
-                              :blacklist_paths => ["#{default_path}/custom_blacklist.txt"])
+                              :blacklist_paths => ["#{default_path}/custom_blacklist.txt"],
+                              :digits => %w[2 3 4 5 6 7 8 9])
   end
 
   subject {memorable_password}
@@ -28,6 +29,11 @@ describe MemorablePassword do
 
     it "should support configurable blacklist paths" do
       subject.blacklist.should include 'blcklst'
+    end
+
+    it "should support configurable digits" do
+      subject.digits.should eq(%w[2 3 4 5 6 7 8 9])
+      subject.non_word_digits.should eq(%w[3 5 6 7 9])
     end
   end
 


### PR DESCRIPTION
Some digits like 1 or 0 might be confused with letters (like I and O) on certain fonts.
For that reason, I'd like to avoid creating passwords that use them and thus the need to make the digits configurable.
